### PR TITLE
Aclarar el requisito del formato del certificado en PEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,6 @@ $invoice = Invoice::create([
 
 ### Factura rectificativa (R1)
 ```php
-use Squareetlabs\VeriFactu\Enums\RectificativeType;
-
 $invoice = Invoice::create([
     'number' => 'INV-RECT-001',
     'date' => '2024-07-01',
@@ -322,8 +320,22 @@ $invoice = Invoice::create([
     'total' => 145.20,
     'type' => InvoiceType::RECTIFICATIVE_R1,
     'rectificative_type' => 'S', // S=Sustitución, I=Diferencia
-    'rectified_invoices' => json_encode(['INV-001', 'INV-002']),
-    'rectification_amount' => json_encode(['base' => -50.00, 'tax' => -10.50, 'total' => -60.50]),
+    'rectified_invoices' => [                      // Facturas sustituidas/rectificadas (issuer_tax_id, number, date)
+        [
+            'issuer_tax_id' => 'B87654321',
+            'number' => 'INV-001',
+            'date' => '2024-06-01',
+        ],
+        [
+            'issuer_tax_id' => 'B87654321',
+            'number' => 'INV-002',
+            'date' => '2024-06-15',
+        ],
+    ],
+    'rectification_amount' => [                   // Obligatorio cuando rectificative_type = 'S'
+        'base' => 100.00,                          // Base de la factura sustituida
+        'tax' => 21.00,                            // Cuota de la factura sustituida
+    ],
 ]);
 ```
 
@@ -416,14 +428,21 @@ $invoice = Invoice::create([
     'number' => 'INV-RECT-001',
     'type' => InvoiceType::RECTIFICATIVE_R1,
     'rectificative_type' => 'I',                    // 'S' = Sustitución, 'I' = Diferencia
-    'rectified_invoices' => [                       // Array de facturas rectificadas
-        'INV-001',
-        'INV-002'
+    'rectified_invoices' => [                       // Array de facturas rectificadas (issuer_tax_id, number, date)
+        [
+            'issuer_tax_id' => 'B12345678',
+            'number' => 'INV-001',
+            'date' => '2024-07-01',                 // Se normaliza a d-m-Y al enviar
+        ],
+        [
+            'issuer_tax_id' => 'B12345678',
+            'number' => 'INV-002',
+            'date' => '2024-07-02',
+        ],
     ],
-    'rectification_amount' => [                     // Importes de rectificación
+    'rectification_amount' => [                     // Obligatorio en 'S', opcional en 'I'
         'base' => -50.00,
         'tax' => -10.50,
-        'total' => -60.50
     ],
     // ... otros campos
 ]);
@@ -517,8 +536,8 @@ $invoice = Invoice::create([
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
 | `rectificative_type` | string\|null | 'S' = Sustitución, 'I' = Diferencia |
-| `rectified_invoices` | array | Array de números de facturas rectificadas |
-| `rectification_amount` | array | Importes de rectificación (base, tax, total) |
+| `rectified_invoices` | array | Array de facturas rectificadas/sustituidas (issuer_tax_id, number, date) |
+| `rectification_amount` | array | Importes de rectificación (base, tax, surcharge). Obligatorio en 'S' |
 
 #### Campos de subsanación
 | Campo | Tipo | Descripción |
@@ -615,11 +634,16 @@ $rectificativeInvoice = Invoice::create([
     'date' => '2024-07-15',
     'type' => InvoiceType::RECTIFICATIVE_R1,
     'rectificative_type' => 'I',                   // I = Diferencia
-    'rectified_invoices' => ['INV-001'],          // Facturas rectificadas
+    'rectified_invoices' => [
+        [
+            'issuer_tax_id' => $originalInvoice->issuer_tax_id,
+            'number' => $originalInvoice->number,
+            'date' => $originalInvoice->date->format('d-m-Y'),
+        ],
+    ],
     'rectification_amount' => [
         'base' => -20.00,                          // Diferencia en base
         'tax' => -4.20,                            // Diferencia en impuesto
-        'total' => -24.20                          // Diferencia total
     ],
     'amount' => -20.00,                            // Importe negativo
     'tax' => -4.20,

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -181,7 +181,11 @@ class Invoice extends Model implements VeriFactuInvoice
 
     public function getCorrectionType(): ?string
     {
-        return $this->correction_type;
+        if (!empty($this->correction_type)) {
+            return $this->correction_type;
+        }
+
+        return $this->rectificative_type ?: null;
     }
 
     public function getExternalReference(): ?string

--- a/src/Services/AeatClient.php
+++ b/src/Services/AeatClient.php
@@ -285,8 +285,23 @@ class AeatClient
             ];
         }
 
-        if ($invoice->getCorrectionType()) {
-            $registroAlta['TipoRectificativa'] = $invoice->getCorrectionType();
+        $rectificativeType = $invoice->getCorrectionType();
+        if ($rectificativeType) {
+            $rectificativeType = strtoupper($rectificativeType);
+            $registroAlta['TipoRectificativa'] = $rectificativeType;
+        }
+
+        $rectifiedInvoices = $this->resolveRectifiedInvoices($invoice, $issuerVat);
+        if ($rectifiedInvoices) {
+            $isSubstitute = strtoupper($tipoFactura) === 'F3';
+            $block = $isSubstitute ? 'FacturasSustituidas' : 'FacturasRectificadas';
+            $itemKey = $isSubstitute ? 'IDFacturaSustituida' : 'IDFacturaRectificada';
+            $registroAlta[$block] = [$itemKey => $rectifiedInvoices];
+        }
+
+        $rectificationAmount = $this->resolveRectificationAmount($invoice);
+        if ($rectificationAmount) {
+            $registroAlta['ImporteRectificacion'] = $rectificationAmount;
         }
 
         if ($invoice->getExternalReference()) {
@@ -298,6 +313,154 @@ class AeatClient
         }
 
         return $registroAlta;
+    }
+
+    private function resolveRectifiedInvoices(VeriFactuInvoice $invoice, string $issuerVat): ?array
+    {
+        $rectified = null;
+
+        if (method_exists($invoice, 'getRectifiedInvoices')) {
+            $rectified = $invoice->getRectifiedInvoices();
+        }
+
+        if ($rectified === null && $invoice instanceof \Illuminate\Database\Eloquent\Model) {
+            $rectified = $invoice->getAttribute('rectified_invoices');
+        }
+
+        if (is_string($rectified)) {
+            $decoded = json_decode($rectified, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $rectified = $decoded;
+            }
+        }
+
+        if (!is_array($rectified) || $rectified === []) {
+            return null;
+        }
+
+        if (array_key_exists('number', $rectified) && array_key_exists('date', $rectified)) {
+            $rectified = [$rectified];
+        }
+
+        $items = [];
+        foreach ($rectified as $item) {
+            $normalized = $this->normalizeRectifiedInvoice($item, $issuerVat);
+            if ($normalized) {
+                $items[] = $normalized;
+            }
+        }
+
+        return $items === [] ? null : $items;
+    }
+
+    private function normalizeRectifiedInvoice(mixed $item, string $issuerVat): ?array
+    {
+        if ($item instanceof \Illuminate\Database\Eloquent\Model) {
+            $item = $item->getAttributes();
+        }
+
+        if (!is_array($item)) {
+            return null;
+        }
+
+        $number = $item['number'] ?? null;
+        $date = $item['date'] ?? null;
+        $issuer = $item['issuer_tax_id'] ?? $item['issuer_vat'] ?? $issuerVat;
+
+        if (empty($number) || empty($date)) {
+            return null;
+        }
+
+        $date = $this->normalizeIssueDate($date);
+
+        if ($date === null) {
+            return null;
+        }
+
+        return [
+            'IDEmisorFactura' => $issuer,
+            'NumSerieFactura' => (string) $number,
+            'FechaExpedicionFactura' => $date,
+        ];
+    }
+
+    private function normalizeIssueDate(mixed $date): ?string
+    {
+        if ($date instanceof \DateTimeInterface) {
+            return $date->format('d-m-Y');
+        }
+
+        if (!is_string($date)) {
+            return null;
+        }
+
+        $date = trim($date);
+        if ($date === '') {
+            return null;
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) === 1) {
+            $parsed = \Carbon\Carbon::createFromFormat('Y-m-d', $date);
+            return $parsed->format('d-m-Y');
+        }
+
+        if (preg_match('/^\d{2}\/\d{2}\/\d{4}$/', $date) === 1) {
+            $parsed = \Carbon\Carbon::createFromFormat('d/m/Y', $date);
+            return $parsed->format('d-m-Y');
+        }
+
+        if (preg_match('/^\d{2}-\d{2}-\d{4}$/', $date) === 1) {
+            return $date;
+        }
+
+        try {
+            return \Carbon\Carbon::parse($date)->format('d-m-Y');
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    private function resolveRectificationAmount(VeriFactuInvoice $invoice): ?array
+    {
+        $amount = null;
+
+        if (method_exists($invoice, 'getRectificationAmount')) {
+            $amount = $invoice->getRectificationAmount();
+        }
+
+        if ($amount === null && $invoice instanceof \Illuminate\Database\Eloquent\Model) {
+            $amount = $invoice->getAttribute('rectification_amount');
+        }
+
+        if (is_string($amount)) {
+            $decoded = json_decode($amount, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $amount = $decoded;
+            }
+        }
+
+        if (!is_array($amount) || $amount === []) {
+            return null;
+        }
+
+        $base = $amount['base'] ?? null;
+        $tax = $amount['tax'] ?? null;
+        $surcharge = $amount['surcharge'] ?? $amount['recargo'] ?? null;
+
+        if ($base === null || $tax === null) {
+            return null;
+        }
+
+        $rectification = [
+            'BaseRectificada' => sprintf('%.2f', (float) $base),
+            'CuotaRectificada' => sprintf('%.2f', (float) $tax),
+        ];
+
+        if ($surcharge !== null) {
+            $rectification['CuotaRecargoRectificado'] = sprintf('%.2f', (float) $surcharge);
+        }
+
+        return $rectification;
     }
 
     protected function getSoapClient(): \SoapClient
@@ -371,4 +534,3 @@ class AeatClient
         }
     }
 }
-


### PR DESCRIPTION
Hola, muchas gracias por crear la librería. Está siendo de gran utilidad.
He detectado que en la documentación no se menciona el tema de los certificados, y me ha llevado bastante tiempo darme cuenta de que actualmente solo se soporta formato PEM, ya que se utiliza el cliente SOAP nativo de PHP, que no admite directamente certificados .p12 / .pfx.

De momento he enviado una PR para dejar esto explícito en la documentación.
Si lo consideráis necesario y entra dentro del roadmap, podría implementarse en el futuro soporte para otros formatos de certificado.

Muchas gracias por vuestro trabajo y por mantener la librería, se agradece mucho.