### PR TITLE
feat: host-chain, colaborador social y API de integración para hosts (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Host-chain & multi-tenant support (Quandium integration)
+- `AeatClient::sendInvoice()` acepta un tercer parámetro `$record` con
+  `['hash' => ..., 'generated_at' => ...]` precalculados. Imprescindible cuando
+  la aplicación host persiste su propia cadena de huellas en el momento de la
+  emisión: la `Huella` y `FechaHoraHusoGenRegistro` remitidas a AEAT deben ser
+  exactamente las almacenadas, nunca recalculadas en el envío asíncrono
+  (recalcularlas con un timestamp nuevo rompería la integridad de la cadena).
+- `AeatClient` acepta un emisor por instancia (5º parámetro del constructor,
+  `['name' => ..., 'vat' => ...]`) para aplicaciones multi-tenant donde cada
+  empresa es un obligado de emisión distinto. Sin él, se mantiene el
+  comportamiento anterior (`config('verifactu.issuer')`).
+
+#### Colaborador social / entidad colaboradora AEAT
+- Soporte de **Representante** en la Cabecera: plataformas registradas como
+  entidad colaboradora remiten en nombre de sus clientes usando el certificado
+  de la PLATAFORMA — los obligados de emisión no necesitan aportar el suyo.
+  Se configura globalmente (`config('verifactu.representative')` /
+  `VERIFACTU_REP_NAME`, `VERIFACTU_REP_VAT`) o por instancia (6º parámetro del
+  constructor de `AeatClient`). Si no se configura, la Cabecera no cambia.
+
+#### API de integración para hosts
+- Contrato `CertificateProvider` + `ConfigCertificateProvider` (por defecto,
+  lee `verifactu.aeat.cert_path/cert_password` y valida que el fichero exista).
+  Los hosts con otro almacén de certificados (por emisor, Vault, S3+KMS...)
+  re-vinculan el contrato en el contenedor.
+- `AeatClientFactory`: construye `AeatClient` desde config + CertificateProvider,
+  con emisor/representante por llamada. El transport de un host queda reducido a
+  mapear su propio registro de cadena.
+- `AeatSubmissionResponse`: DTO tipado sobre el array crudo de `sendInvoice()`.
+  Parsea `EstadoEnvio`, `CSV` y `RespuestaLinea` (única o lista) con
+  `accepted()` / `partiallyAccepted()` / `rejected()` / `firstError()` /
+  `toArray()` — antes cada consumidor escarbaba el stdClass del SOAP a mano.
+- Bindings registrados en `VeriFactuServiceProvider` (`CertificateProvider` →
+  `ConfigCertificateProvider`, `AeatClientFactory` singleton).
+
+### Changed
+- `AeatClient::buildFingerprint()` delega en `HashHelper::generateInvoiceHash()`:
+  una única implementación de la especificación de huella AEAT v0.1.2 (antes
+  estaba duplicada y solo `HashHelper` tenía tests de conformidad).
+
+### Fixed
+- Tests `AeatClientHybridTest` y `ContractComplianceTest`: las implementaciones
+  anónimas de `VeriFactuInvoice` no compilaban tras añadirse los métodos
+  `getCorrectedBaseAmount/TaxAmount/SurchargeAmount` al contrato.
+
 #### Core Features (Issue #6 + PR #8)
 - Soporte para dos modos de facturación: VERIFACTU y NO VERIFACTU (Requerimiento)
 - Nuevo parámetro de configuración `verifactu_mode` para alternar entre modos

--- a/README.md
+++ b/README.md
@@ -98,6 +98,60 @@ El paquete ajustará automáticamente las URLs del servicio SOAP según el modo 
 - **Pruebas VERIFACTU**: `https://prewww1.aeat.es/wlpl/TIKE-CONT/ws/SistemaFacturacion/VerifactuSOAP`
 - **Pruebas NO VERIFACTU**: `https://prewww1.aeat.es/wlpl/TIKE-CONT/ws/SistemaFacturacion/RequerimientoSOAP`
 
+### Colaborador social (entidad colaboradora AEAT)
+
+Si tu plataforma está registrada como **entidad colaboradora** de la AEAT, puedes
+remitir registros en nombre de tus clientes usando **el certificado de la
+plataforma**: los obligados de emisión (autónomos, pymes…) no necesitan aportar
+su propio certificado digital.
+
+```env
+# Identidad del colaborador social (añade el bloque Representante a la Cabecera)
+VERIFACTU_REP_NAME="Mi Plataforma SL"
+VERIFACTU_REP_VAT=B99999999
+
+# El certificado configurado debe ser el del COLABORADOR, no el del emisor
+VERIFACTU_CERT_PATH=/ruta/certificado-plataforma.pem
+```
+
+En aplicaciones multi-tenant, usa `AeatClientFactory` (resuelve el certificado
+vía el contrato `CertificateProvider`, por defecto desde config):
+
+```php
+use Squareetlabs\VeriFactu\Services\AeatClientFactory;
+use Squareetlabs\VeriFactu\Services\AeatSubmissionResponse;
+
+$client = app(AeatClientFactory::class)->make(
+    issuer: ['name' => $company->legal_name, 'vat' => $company->tax_id],
+    representative: config('verifactu.representative'),
+);
+
+// Huella y timestamp precalculados de tu propia cadena (ver $record):
+$result = $client->sendInvoice($invoice, $previous, [
+    'hash' => $record->hash,
+    'generated_at' => $record->generated_at,
+]);
+
+// Respuesta tipada: EstadoEnvio, CSV y errores por línea ya parseados
+$response = AeatSubmissionResponse::fromClientResult($result);
+
+if ($response->accepted()) {
+    // EstadoEnvio = Correcto; $response->csv disponible
+} else {
+    Log::warning('AEAT rechazo', ['error' => $response->firstError()]);
+}
+```
+
+Si tu aplicación guarda los certificados en otro sitio (por emisor, cifrados,
+Vault, S3+KMS...), implementa el contrato y re-vincúlalo:
+
+```php
+$this->app->bind(
+    \Squareetlabs\VeriFactu\Contracts\CertificateProvider::class,
+    \App\Services\MyCertificateStore::class,
+);
+```
+
 ### Parámetros del Sistema Informático
 
 Configura los parámetros según las características de tu sistema:

--- a/config/verifactu.php
+++ b/config/verifactu.php
@@ -11,6 +11,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Representative (Colaborador Social)
+    |--------------------------------------------------------------------------
+    |
+    | For platforms registered as "entidad colaboradora" (colaborador social)
+    | with AEAT: invoices are submitted on behalf of the issuer using the
+    | PLATFORM's certificate, so issuers never have to provide their own.
+    | When 'vat' is set, a Representante block is added to the Cabecera of
+    | every submission. The TLS certificate configured under 'aeat' must then
+    | be the collaborator's certificate.
+    |
+    */
+    'representative' => [
+        'name' => env('VERIFACTU_REP_NAME', ''),
+        'vat' => env('VERIFACTU_REP_VAT', ''),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Verifactu Mode
     |--------------------------------------------------------------------------
     |

--- a/src/Contracts/CertificateProvider.php
+++ b/src/Contracts/CertificateProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Squareetlabs\VeriFactu\Contracts;
+
+use Squareetlabs\VeriFactu\Services\CertificateRef;
+
+/**
+ * Resolves the client certificate used to authenticate against AEAT.
+ *
+ * The default implementation (ConfigCertificateProvider) reads a single
+ * platform certificate from config — the right fit for "entidad colaboradora"
+ * platforms that submit on behalf of all their clients.
+ *
+ * Hosts with other storage models (per-issuer certificates, encrypted stores,
+ * Vault, S3+KMS...) bind their own implementation in the container:
+ *
+ *     $this->app->bind(CertificateProvider::class, MyCertificateStore::class);
+ */
+interface CertificateProvider
+{
+    /**
+     * @param string|null $issuerVat NIF of the obligado emisión, for providers
+     *        that resolve a different certificate per issuer. The default
+     *        config-based provider ignores it.
+     */
+    public function resolve(?string $issuerVat = null): CertificateRef;
+}

--- a/src/Providers/VeriFactuServiceProvider.php
+++ b/src/Providers/VeriFactuServiceProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Squareetlabs\VeriFactu\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Squareetlabs\VeriFactu\Contracts\CertificateProvider;
+use Squareetlabs\VeriFactu\Services\AeatClientFactory;
+use Squareetlabs\VeriFactu\Services\ConfigCertificateProvider;
 
 class VeriFactuServiceProvider extends ServiceProvider
 {
@@ -13,8 +16,14 @@ class VeriFactuServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // Registrar bindings, singletons, etc.
         $this->mergeConfigFrom(__DIR__ . '/../../config/verifactu.php', 'verifactu');
+
+        // Certificado por defecto desde config (plataforma / colaborador social).
+        // Los hosts con otro almacén (por emisor, Vault, S3+KMS...) re-vinculan
+        // CertificateProvider a su propia implementación.
+        $this->app->bind(CertificateProvider::class, ConfigCertificateProvider::class);
+
+        $this->app->singleton(AeatClientFactory::class);
     }
 
     /**

--- a/src/Services/AeatClient.php
+++ b/src/Services/AeatClient.php
@@ -7,6 +7,7 @@ namespace Squareetlabs\VeriFactu\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
+use Squareetlabs\VeriFactu\Helpers\HashHelper;
 use Squareetlabs\VeriFactu\Models\Invoice;
 use Illuminate\Support\Facades\Log;
 
@@ -19,12 +20,41 @@ class AeatClient
     private bool $production;
     private bool $verifactuMode;
 
-    public function __construct(string $certPath, ?string $certPassword = null, bool $production = false, ?bool $verifactuMode = null)
-    {
+    /** @var array{name: string, vat: string} */
+    private array $issuer;
+
+    /** @var array{name: string, vat: string}|null */
+    private ?array $representative;
+
+    /**
+     * @param array{name: string, vat: string}|null $issuer Issuer (obligado emisión).
+     *        Defaults to config('verifactu.issuer'). Pass it explicitly in
+     *        multi-tenant applications where each company is a different issuer.
+     * @param array{name: string, vat: string}|null $representative Social
+     *        collaborator / representative (colaborador social AEAT). When set,
+     *        a Representante block is added to the Cabecera and the TLS client
+     *        certificate is expected to be the COLLABORATOR's, not the issuer's:
+     *        the platform submits on behalf of its clients, who never have to
+     *        provide their own certificate. Defaults to
+     *        config('verifactu.representative') when it has a non-empty vat.
+     */
+    public function __construct(
+        string $certPath,
+        ?string $certPassword = null,
+        bool $production = false,
+        ?bool $verifactuMode = null,
+        ?array $issuer = null,
+        ?array $representative = null
+    ) {
         $this->certPath = $certPath;
         $this->certPassword = $certPassword;
         $this->production = $production;
         $this->verifactuMode = $verifactuMode ?? config('verifactu.verifactu_mode', true);
+        $this->issuer = $issuer ?? (array) config('verifactu.issuer', ['name' => '', 'vat' => '']);
+
+        $configRepresentative = (array) config('verifactu.representative', []);
+        $this->representative = $representative
+            ?? (!empty($configRepresentative['vat']) ? $configRepresentative : null);
         $this->baseUri = $production
             ? 'https://www1.aeat.es'
             : 'https://prewww1.aeat.es';
@@ -37,10 +67,9 @@ class AeatClient
         ]);
     }
 
-
-
     /**
-     * Build fingerprint/hash for invoice chaining
+     * Build fingerprint/hash for invoice chaining.
+     * Delegates to HashHelper: single source of truth for the AEAT hash spec.
      *
      * @param string $issuerVat
      * @param string $numSerie
@@ -62,47 +91,39 @@ class AeatClient
         string $ts,
         string $prevHash = ''
     ): string {
-        $raw = 'IDEmisorFactura=' . $issuerVat
-            . '&NumSerieFactura=' . $numSerie
-            . '&FechaExpedicionFactura=' . $fechaExp
-            . '&TipoFactura=' . $tipoFactura
-            . '&CuotaTotal=' . $cuotaTotal
-            . '&ImporteTotal=' . $importeTotal
-            . '&Huella=' . $prevHash
-            . '&FechaHoraHusoGenRegistro=' . $ts;
-        return strtoupper(hash('sha256', $raw));
+        return HashHelper::generateInvoiceHash([
+            'issuer_tax_id' => $issuerVat,
+            'invoice_number' => $numSerie,
+            'issue_date' => $fechaExp,
+            'invoice_type' => $tipoFactura,
+            'total_tax' => $cuotaTotal,
+            'total_amount' => $importeTotal,
+            'previous_hash' => $prevHash,
+            'generated_at' => $ts,
+        ])['hash'];
     }
 
     /**
      * Send invoice registration to AEAT with support for invoice chaining
      *
-     * @param Invoice $invoice
-     * @param array|null $previous Previous invoice data for chaining (hash, number, date)
-     * @return array
-     */
-    /**
-     * Send invoice registration to AEAT with support for invoice chaining
-     *
      * @param VeriFactuInvoice $invoice
      * @param array|null $previous Previous invoice data for chaining (hash, number, date)
+     * @param array|null $record Precomputed registration record data:
+     *        ['hash' => string, 'generated_at' => string (ISO 8601)].
+     *        REQUIRED when the host application persists its own hash chain at
+     *        issuance time: the submitted Huella and FechaHoraHusoGenRegistro
+     *        must be exactly the ones stored in the chain, never recomputed at
+     *        submission time (async submission would break chain integrity).
      * @return array
      */
-    /**
-     * Send invoice registration to AEAT with support for invoice chaining
-     *
-     * @param VeriFactuInvoice $invoice
-     * @param array|null $previous Previous invoice data for chaining (hash, number, date)
-     * @return array
-     */
-    public function sendInvoice(VeriFactuInvoice $invoice, ?array $previous = null): array
+    public function sendInvoice(VeriFactuInvoice $invoice, ?array $previous = null, ?array $record = null): array
     {
-        // 1. Obtener datos del emisor
-        $issuer = config('verifactu.issuer');
-        $issuerName = $issuer['name'] ?? '';
-        $issuerVat = $issuer['vat'] ?? '';
+        // 1. Obtener datos del emisor (por instancia; multi-tenant friendly)
+        $issuerName = $this->issuer['name'] ?? '';
+        $issuerVat = $this->issuer['vat'] ?? '';
 
         // 2. Preparar datos comunes
-        $ts = \Carbon\Carbon::now('UTC')->format('c');
+        $ts = $record['generated_at'] ?? \Carbon\Carbon::now('UTC')->format('c');
         $numSerie = (string) $invoice->getInvoiceNumber();
         $fechaExp = $invoice->getIssueDate()->format('d-m-Y');
         $tipoFactura = $invoice->getInvoiceType();
@@ -110,8 +131,8 @@ class AeatClient
         $importeTotal = sprintf('%.2f', (float) $invoice->getTotalAmount());
         $prevHash = $previous['hash'] ?? $invoice->getPreviousHash() ?? '';
 
-        // 3. Generar huella
-        $huella = $this->buildFingerprint(
+        // 3. Huella: la precalculada de la cadena del host si existe; si no, generarla
+        $huella = $record['hash'] ?? $this->buildFingerprint(
             $issuerVat,
             $numSerie,
             $fechaExp,
@@ -158,12 +179,23 @@ class AeatClient
 
     private function buildHeader(string $issuerName, string $issuerVat): array
     {
-        return [
+        $cabecera = [
             'ObligadoEmision' => [
                 'NombreRazon' => $issuerName,
                 'NIF' => $issuerVat,
             ],
         ];
+
+        // Colaborador social: la plataforma remite en nombre del obligado con
+        // su propio certificado; AEAT exige identificar al representante.
+        if ($this->representative !== null) {
+            $cabecera['Representante'] = [
+                'NombreRazon' => $this->representative['name'] ?? '',
+                'NIF' => $this->representative['vat'] ?? '',
+            ];
+        }
+
+        return $cabecera;
     }
 
     private function buildBreakdowns(VeriFactuInvoice $invoice): array

--- a/src/Services/AeatClientFactory.php
+++ b/src/Services/AeatClientFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Squareetlabs\VeriFactu\Services;
+
+use Squareetlabs\VeriFactu\Contracts\CertificateProvider;
+
+/**
+ * Builds ready-to-use AeatClient instances from configuration plus the bound
+ * CertificateProvider, so host applications don't repeat the wiring.
+ *
+ * Multi-tenant / colaborador social usage:
+ *
+ *     $client = app(AeatClientFactory::class)->make(
+ *         issuer: ['name' => $company->legal_name, 'vat' => $company->tax_id],
+ *         representative: config('verifactu.representative'),
+ *     );
+ *
+ * Single-issuer usage (everything from config):
+ *
+ *     $client = app(AeatClientFactory::class)->make();
+ */
+class AeatClientFactory
+{
+    public function __construct(private readonly CertificateProvider $certificates)
+    {
+    }
+
+    /**
+     * @param array{name: string, vat: string}|null $issuer Obligado emisión.
+     *        Defaults to config('verifactu.issuer').
+     * @param array{name: string, vat: string}|null $representative Colaborador
+     *        social. Defaults to config('verifactu.representative') when set.
+     */
+    public function make(
+        ?array $issuer = null,
+        ?array $representative = null,
+        ?bool $verifactuMode = null
+    ): AeatClient {
+        $certificate = $this->certificates->resolve($issuer['vat'] ?? null);
+
+        return new AeatClient(
+            certPath: $certificate->path,
+            certPassword: $certificate->password,
+            production: (bool) config('verifactu.aeat.production', false),
+            verifactuMode: $verifactuMode,
+            issuer: $issuer,
+            representative: $representative,
+        );
+    }
+}

--- a/src/Services/AeatSubmissionResponse.php
+++ b/src/Services/AeatSubmissionResponse.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Squareetlabs\VeriFactu\Services;
+
+/**
+ * Typed view over the raw array returned by AeatClient::sendInvoice().
+ *
+ * Parses the AEAT RespuestaRegFactuSistemaFacturacion structure so consumers
+ * don't have to dig through the SOAP stdClass themselves:
+ *
+ *     $response = AeatSubmissionResponse::fromClientResult(
+ *         $client->sendInvoice($invoice, $previous, $record)
+ *     );
+ *
+ *     if ($response->accepted()) { ... }
+ *
+ * EstadoEnvio values: Correcto | ParcialmenteCorrecto | Incorrecto.
+ * Per-line EstadoRegistro values: Correcto | AceptadoConErrores | Incorrecto.
+ */
+final class AeatSubmissionResponse
+{
+    public const SEND_CORRECT = 'Correcto';
+    public const SEND_PARTIALLY_CORRECT = 'ParcialmenteCorrecto';
+    public const SEND_INCORRECT = 'Incorrecto';
+
+    /**
+     * @param list<array{invoice_number: ?string, status: ?string, error_code: ?string, error_description: ?string}> $lines
+     */
+    private function __construct(
+        public readonly bool $transportSuccess,
+        public readonly ?string $sendStatus,
+        public readonly ?string $csv,
+        public readonly array $lines,
+        public readonly ?string $errorMessage,
+        public readonly ?string $rawRequest,
+        public readonly ?string $rawResponse,
+    ) {
+    }
+
+    public static function fromClientResult(array $result): self
+    {
+        $transportSuccess = ($result['status'] ?? null) === 'success';
+
+        $aeat = $result['aeat_response'] ?? null;
+        // SoapClient returns nested stdClass; normalise to arrays once.
+        $aeat = $aeat === null ? [] : (json_decode(json_encode($aeat), true) ?: []);
+
+        return new self(
+            transportSuccess: $transportSuccess,
+            sendStatus: $aeat['EstadoEnvio'] ?? null,
+            csv: $aeat['CSV'] ?? null,
+            lines: self::parseLines($aeat['RespuestaLinea'] ?? null),
+            errorMessage: $result['message'] ?? null,
+            rawRequest: $result['request'] ?? null,
+            rawResponse: $result['response'] ?? null,
+        );
+    }
+
+    /** SOAP call succeeded and AEAT accepted every record. */
+    public function accepted(): bool
+    {
+        return $this->transportSuccess && $this->sendStatus === self::SEND_CORRECT;
+    }
+
+    /** SOAP call succeeded but AEAT rejected some (not all) records. */
+    public function partiallyAccepted(): bool
+    {
+        return $this->transportSuccess && $this->sendStatus === self::SEND_PARTIALLY_CORRECT;
+    }
+
+    public function rejected(): bool
+    {
+        return !$this->transportSuccess || $this->sendStatus === self::SEND_INCORRECT;
+    }
+
+    /** First error found (transport-level or per-line), for logging. */
+    public function firstError(): ?string
+    {
+        if ($this->errorMessage !== null) {
+            return $this->errorMessage;
+        }
+
+        foreach ($this->lines as $line) {
+            if (!empty($line['error_description']) || !empty($line['error_code'])) {
+                return trim(($line['error_code'] ?? '') . ' ' . ($line['error_description'] ?? ''));
+            }
+        }
+
+        return null;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'transport_success' => $this->transportSuccess,
+            'send_status' => $this->sendStatus,
+            'csv' => $this->csv,
+            'lines' => $this->lines,
+            'error_message' => $this->errorMessage,
+        ];
+    }
+
+    /**
+     * RespuestaLinea arrives as a single object or a list depending on how
+     * many records were submitted.
+     */
+    private static function parseLines(mixed $respuestaLinea): array
+    {
+        if (!is_array($respuestaLinea)) {
+            return [];
+        }
+
+        // Single line: associative array -> wrap into a list.
+        if ($respuestaLinea !== [] && !array_is_list($respuestaLinea)) {
+            $respuestaLinea = [$respuestaLinea];
+        }
+
+        return array_map(static fn (array $line) => [
+            'invoice_number' => $line['IDFactura']['NumSerieFactura'] ?? null,
+            'status' => $line['EstadoRegistro'] ?? null,
+            'error_code' => isset($line['CodigoErrorRegistro']) ? (string) $line['CodigoErrorRegistro'] : null,
+            'error_description' => $line['DescripcionErrorRegistro'] ?? null,
+        ], $respuestaLinea);
+    }
+}

--- a/src/Services/CertificateRef.php
+++ b/src/Services/CertificateRef.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Squareetlabs\VeriFactu\Services;
+
+/**
+ * Reference to a client certificate usable by ext-soap (local file path).
+ */
+final class CertificateRef
+{
+    public function __construct(
+        public readonly string $path,
+        public readonly ?string $password = null,
+    ) {
+    }
+}

--- a/src/Services/ConfigCertificateProvider.php
+++ b/src/Services/ConfigCertificateProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Squareetlabs\VeriFactu\Services;
+
+use Squareetlabs\VeriFactu\Contracts\CertificateProvider;
+use Squareetlabs\VeriFactu\Exceptions\VeriFactuException;
+
+/**
+ * Default certificate provider: a single certificate configured under
+ * verifactu.aeat.cert_path / cert_password.
+ *
+ * This is the natural fit for platforms operating as AEAT "entidad
+ * colaboradora": one platform certificate submits on behalf of every issuer,
+ * so issuers never provide their own.
+ */
+class ConfigCertificateProvider implements CertificateProvider
+{
+    public function resolve(?string $issuerVat = null): CertificateRef
+    {
+        $path = (string) config('verifactu.aeat.cert_path', '');
+
+        if ($path === '') {
+            throw new VeriFactuException(
+                'No certificate configured: set verifactu.aeat.cert_path (VERIFACTU_CERT_PATH).'
+            );
+        }
+
+        if (!is_file($path)) {
+            throw new VeriFactuException(
+                "Certificate file not found or not readable: {$path}"
+            );
+        }
+
+        $password = config('verifactu.aeat.cert_password');
+
+        return new CertificateRef($path, $password === null ? null : (string) $password);
+    }
+}

--- a/tests/Support/InteractsWithAeatClient.php
+++ b/tests/Support/InteractsWithAeatClient.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
+use Squareetlabs\VeriFactu\Enums\InvoiceType;
+use Squareetlabs\VeriFactu\Services\AeatClient;
+
+/**
+ * Helpers compartidos para tests de AeatClient: cliente con SoapClient
+ * mockeado (sin llamadas de red) y mock de factura mínima válida.
+ */
+trait InteractsWithAeatClient
+{
+    /**
+     * SoapClient mockeado que valida el body enviado a RegFactuSistemaFacturacion.
+     *
+     * @param callable(array $args): bool $assertion
+     */
+    protected function mockSoapExpecting(callable $assertion): \SoapClient
+    {
+        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
+            ->getMock();
+
+        $soapClientMock->expects($this->once())
+            ->method('__soapCall')
+            ->with('RegFactuSistemaFacturacion', $this->callback($assertion))
+            ->willReturn(new \stdClass());
+
+        return $soapClientMock;
+    }
+
+    /**
+     * AeatClient real con el transporte SOAP sustituido por el mock.
+     */
+    protected function makeAeatClient(
+        \SoapClient $soapClientMock,
+        ?array $issuer = null,
+        ?array $representative = null
+    ): AeatClient {
+        return new class ('/path/cert.pem', 'pwd', false, true, $issuer, $representative, $soapClientMock) extends AeatClient {
+            private $soapClientMock;
+
+            public function __construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative, $soapClientMock)
+            {
+                parent::__construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative);
+                $this->soapClientMock = $soapClientMock;
+            }
+
+            protected function getSoapClient(): \SoapClient
+            {
+                return $this->soapClientMock;
+            }
+        };
+    }
+
+    /**
+     * Factura mínima válida (F1, 100€ + 21% IVA) con overrides puntuales.
+     *
+     * @param array<string, mixed> $overrides método del contrato => valor
+     */
+    protected function makeInvoiceMock(array $overrides = []): VeriFactuInvoice
+    {
+        $defaults = [
+            'getInvoiceNumber' => 'FAC-2026-000001',
+            'getIssueDate' => now(),
+            'getInvoiceType' => InvoiceType::STANDARD->value,
+            'getTotalAmount' => 121.0,
+            'getTaxAmount' => 21.0,
+            'getBreakdowns' => collect(),
+            'getRecipients' => collect(),
+            'getPreviousHash' => null,
+            'getOperationDescription' => 'Venta',
+            'getOperationDate' => null,
+            'getTaxPeriod' => null,
+            'getCorrectionType' => null,
+            'getExternalReference' => null,
+        ];
+
+        $invoiceMock = $this->createMock(VeriFactuInvoice::class);
+
+        foreach ([...$defaults, ...$overrides] as $method => $value) {
+            $invoiceMock->method($method)->willReturn($value);
+        }
+
+        return $invoiceMock;
+    }
+}

--- a/tests/Unit/AeatClientFactoryTest.php
+++ b/tests/Unit/AeatClientFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Squareetlabs\VeriFactu\Contracts\CertificateProvider;
+use Squareetlabs\VeriFactu\Services\AeatClient;
+use Squareetlabs\VeriFactu\Services\AeatClientFactory;
+use Squareetlabs\VeriFactu\Services\CertificateRef;
+use Illuminate\Support\Facades\Config;
+
+class AeatClientFactoryTest extends TestCase
+{
+    public function testBuildsClientWithIssuerRepresentativeAndProviderCertificate(): void
+    {
+        Config::set('verifactu.aeat.production', false);
+
+        $provider = $this->createMock(CertificateProvider::class);
+        $provider->expects($this->once())
+            ->method('resolve')
+            ->with('B11111111') // recibe el NIF del emisor para providers por-emisor
+            ->willReturn(new CertificateRef('/certs/platform.pem', 'pwd'));
+
+        $factory = new AeatClientFactory($provider);
+
+        $client = $factory->make(
+            issuer: ['name' => 'Tenant SL', 'vat' => 'B11111111'],
+            representative: ['name' => 'Plataforma SL', 'vat' => 'B99999999'],
+        );
+
+        $this->assertInstanceOf(AeatClient::class, $client);
+        $this->assertEquals('/certs/platform.pem', $this->prop($client, 'certPath'));
+        $this->assertEquals('pwd', $this->prop($client, 'certPassword'));
+        $this->assertEquals(['name' => 'Tenant SL', 'vat' => 'B11111111'], $this->prop($client, 'issuer'));
+        $this->assertEquals(['name' => 'Plataforma SL', 'vat' => 'B99999999'], $this->prop($client, 'representative'));
+        $this->assertFalse($this->prop($client, 'production'));
+    }
+
+    public function testDefaultsToConfigIssuerWhenNoneGiven(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Config Issuer', 'vat' => 'A00000000']);
+        Config::set('verifactu.representative', ['name' => '', 'vat' => '']);
+
+        $provider = $this->createMock(CertificateProvider::class);
+        $provider->method('resolve')->willReturn(new CertificateRef('/certs/platform.pem'));
+
+        $client = (new AeatClientFactory($provider))->make();
+
+        $this->assertEquals(['name' => 'Config Issuer', 'vat' => 'A00000000'], $this->prop($client, 'issuer'));
+        $this->assertNull($this->prop($client, 'representative'));
+    }
+
+    public function testIsResolvableFromContainer(): void
+    {
+        $this->assertInstanceOf(
+            AeatClientFactory::class,
+            $this->app->make(AeatClientFactory::class),
+        );
+    }
+
+    private function prop(AeatClient $client, string $property): mixed
+    {
+        $ref = new \ReflectionProperty(AeatClient::class, $property);
+
+        return $ref->getValue($client);
+    }
+}

--- a/tests/Unit/AeatClientHostChainTest.php
+++ b/tests/Unit/AeatClientHostChainTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Tests\TestCase;
-use Squareetlabs\VeriFactu\Services\AeatClient;
-use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
-use Squareetlabs\VeriFactu\Enums\InvoiceType;
+use Tests\Support\InteractsWithAeatClient;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -20,6 +18,8 @@ use Illuminate\Support\Facades\Config;
  */
 class AeatClientHostChainTest extends TestCase
 {
+    use InteractsWithAeatClient;
+
     private const PRECOMPUTED_HASH = 'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
     private const GENERATED_AT = '2026-06-10T10:00:00+00:00';
 
@@ -27,25 +27,14 @@ class AeatClientHostChainTest extends TestCase
     {
         Config::set('verifactu.issuer', ['name' => 'Config Issuer', 'vat' => 'B00000000']);
 
-        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
-            ->getMock();
+        $soapClientMock = $this->mockSoapExpecting(function ($args) {
+            $registroAlta = $args[0]['RegistroFactura'][0]['RegistroAlta'];
 
-        $soapClientMock->expects($this->once())
-            ->method('__soapCall')
-            ->with(
-                'RegFactuSistemaFacturacion',
-                $this->callback(function ($args) {
-                    $registroAlta = $args[0]['RegistroFactura'][0]['RegistroAlta'];
+            return $registroAlta['Huella'] === self::PRECOMPUTED_HASH
+                && $registroAlta['FechaHoraHusoGenRegistro'] === self::GENERATED_AT;
+        });
 
-                    return $registroAlta['Huella'] === self::PRECOMPUTED_HASH
-                        && $registroAlta['FechaHoraHusoGenRegistro'] === self::GENERATED_AT;
-                })
-            )
-            ->willReturn(new \stdClass());
-
-        $client = $this->makeClient($soapClientMock);
+        $client = $this->makeAeatClient($soapClientMock);
 
         $result = $client->sendInvoice($this->makeInvoiceMock(), null, [
             'hash' => self::PRECOMPUTED_HASH,
@@ -61,27 +50,16 @@ class AeatClientHostChainTest extends TestCase
     {
         Config::set('verifactu.issuer', ['name' => 'Config Issuer', 'vat' => 'B00000000']);
 
-        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
-            ->getMock();
+        $soapClientMock = $this->mockSoapExpecting(function ($args) {
+            $body = $args[0];
+            $registroAlta = $body['RegistroFactura'][0]['RegistroAlta'];
 
-        $soapClientMock->expects($this->once())
-            ->method('__soapCall')
-            ->with(
-                'RegFactuSistemaFacturacion',
-                $this->callback(function ($args) {
-                    $body = $args[0];
-                    $registroAlta = $body['RegistroFactura'][0]['RegistroAlta'];
+            return $body['Cabecera']['ObligadoEmision']['NIF'] === 'B11111111'
+                && $body['Cabecera']['ObligadoEmision']['NombreRazon'] === 'Tenant Company SL'
+                && $registroAlta['IDFactura']['IDEmisorFactura'] === 'B11111111';
+        });
 
-                    return $body['Cabecera']['ObligadoEmision']['NIF'] === 'B11111111'
-                        && $body['Cabecera']['ObligadoEmision']['NombreRazon'] === 'Tenant Company SL'
-                        && $registroAlta['IDFactura']['IDEmisorFactura'] === 'B11111111';
-                })
-            )
-            ->willReturn(new \stdClass());
-
-        $client = $this->makeClient($soapClientMock, [
+        $client = $this->makeAeatClient($soapClientMock, issuer: [
             'name' => 'Tenant Company SL',
             'vat' => 'B11111111',
         ]);
@@ -89,43 +67,5 @@ class AeatClientHostChainTest extends TestCase
         $result = $client->sendInvoice($this->makeInvoiceMock());
 
         $this->assertEquals('success', $result['status']);
-    }
-
-    private function makeClient(\SoapClient $soapClientMock, ?array $issuer = null): AeatClient
-    {
-        return new class ('/path/to/cert.pem', 'password', false, true, $issuer, $soapClientMock) extends AeatClient {
-            private $soapClientMock;
-
-            public function __construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $soapClientMock)
-            {
-                parent::__construct($certPath, $certPassword, $production, $verifactuMode, $issuer);
-                $this->soapClientMock = $soapClientMock;
-            }
-
-            protected function getSoapClient(): \SoapClient
-            {
-                return $this->soapClientMock;
-            }
-        };
-    }
-
-    private function makeInvoiceMock(): VeriFactuInvoice
-    {
-        $invoiceMock = $this->createMock(VeriFactuInvoice::class);
-        $invoiceMock->method('getInvoiceNumber')->willReturn('FAC-2026-000001');
-        $invoiceMock->method('getIssueDate')->willReturn(now());
-        $invoiceMock->method('getInvoiceType')->willReturn(InvoiceType::STANDARD->value);
-        $invoiceMock->method('getTotalAmount')->willReturn(121.0);
-        $invoiceMock->method('getTaxAmount')->willReturn(21.0);
-        $invoiceMock->method('getBreakdowns')->willReturn(collect());
-        $invoiceMock->method('getRecipients')->willReturn(collect());
-        $invoiceMock->method('getPreviousHash')->willReturn(null);
-        $invoiceMock->method('getOperationDescription')->willReturn('Venta');
-        $invoiceMock->method('getOperationDate')->willReturn(null);
-        $invoiceMock->method('getTaxPeriod')->willReturn(null);
-        $invoiceMock->method('getCorrectionType')->willReturn(null);
-        $invoiceMock->method('getExternalReference')->willReturn(null);
-
-        return $invoiceMock;
     }
 }

--- a/tests/Unit/AeatClientHostChainTest.php
+++ b/tests/Unit/AeatClientHostChainTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Squareetlabs\VeriFactu\Services\AeatClient;
+use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
+use Squareetlabs\VeriFactu\Enums\InvoiceType;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Covers the host-chain integration features:
+ *  - sendInvoice() must submit a precomputed hash and generated_at timestamp
+ *    verbatim (apps that persist their own chain at issuance time would break
+ *    chain integrity if the client recomputed them at submission time).
+ *  - Per-instance issuer for multi-tenant hosts where each company is a
+ *    different obligado emisión.
+ */
+class AeatClientHostChainTest extends TestCase
+{
+    private const PRECOMPUTED_HASH = 'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
+    private const GENERATED_AT = '2026-06-10T10:00:00+00:00';
+
+    public function testPrecomputedRecordHashAndTimestampAreSubmittedVerbatim(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Config Issuer', 'vat' => 'B00000000']);
+
+        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
+            ->getMock();
+
+        $soapClientMock->expects($this->once())
+            ->method('__soapCall')
+            ->with(
+                'RegFactuSistemaFacturacion',
+                $this->callback(function ($args) {
+                    $registroAlta = $args[0]['RegistroFactura'][0]['RegistroAlta'];
+
+                    return $registroAlta['Huella'] === self::PRECOMPUTED_HASH
+                        && $registroAlta['FechaHoraHusoGenRegistro'] === self::GENERATED_AT;
+                })
+            )
+            ->willReturn(new \stdClass());
+
+        $client = $this->makeClient($soapClientMock);
+
+        $result = $client->sendInvoice($this->makeInvoiceMock(), null, [
+            'hash' => self::PRECOMPUTED_HASH,
+            'generated_at' => self::GENERATED_AT,
+        ]);
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertEquals(self::PRECOMPUTED_HASH, $result['hash']);
+        $this->assertEquals(self::GENERATED_AT, $result['timestamp']);
+    }
+
+    public function testPerInstanceIssuerOverridesConfig(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Config Issuer', 'vat' => 'B00000000']);
+
+        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
+            ->getMock();
+
+        $soapClientMock->expects($this->once())
+            ->method('__soapCall')
+            ->with(
+                'RegFactuSistemaFacturacion',
+                $this->callback(function ($args) {
+                    $body = $args[0];
+                    $registroAlta = $body['RegistroFactura'][0]['RegistroAlta'];
+
+                    return $body['Cabecera']['ObligadoEmision']['NIF'] === 'B11111111'
+                        && $body['Cabecera']['ObligadoEmision']['NombreRazon'] === 'Tenant Company SL'
+                        && $registroAlta['IDFactura']['IDEmisorFactura'] === 'B11111111';
+                })
+            )
+            ->willReturn(new \stdClass());
+
+        $client = $this->makeClient($soapClientMock, [
+            'name' => 'Tenant Company SL',
+            'vat' => 'B11111111',
+        ]);
+
+        $result = $client->sendInvoice($this->makeInvoiceMock());
+
+        $this->assertEquals('success', $result['status']);
+    }
+
+    private function makeClient(\SoapClient $soapClientMock, ?array $issuer = null): AeatClient
+    {
+        return new class ('/path/to/cert.pem', 'password', false, true, $issuer, $soapClientMock) extends AeatClient {
+            private $soapClientMock;
+
+            public function __construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $soapClientMock)
+            {
+                parent::__construct($certPath, $certPassword, $production, $verifactuMode, $issuer);
+                $this->soapClientMock = $soapClientMock;
+            }
+
+            protected function getSoapClient(): \SoapClient
+            {
+                return $this->soapClientMock;
+            }
+        };
+    }
+
+    private function makeInvoiceMock(): VeriFactuInvoice
+    {
+        $invoiceMock = $this->createMock(VeriFactuInvoice::class);
+        $invoiceMock->method('getInvoiceNumber')->willReturn('FAC-2026-000001');
+        $invoiceMock->method('getIssueDate')->willReturn(now());
+        $invoiceMock->method('getInvoiceType')->willReturn(InvoiceType::STANDARD->value);
+        $invoiceMock->method('getTotalAmount')->willReturn(121.0);
+        $invoiceMock->method('getTaxAmount')->willReturn(21.0);
+        $invoiceMock->method('getBreakdowns')->willReturn(collect());
+        $invoiceMock->method('getRecipients')->willReturn(collect());
+        $invoiceMock->method('getPreviousHash')->willReturn(null);
+        $invoiceMock->method('getOperationDescription')->willReturn('Venta');
+        $invoiceMock->method('getOperationDate')->willReturn(null);
+        $invoiceMock->method('getTaxPeriod')->willReturn(null);
+        $invoiceMock->method('getCorrectionType')->willReturn(null);
+        $invoiceMock->method('getExternalReference')->willReturn(null);
+
+        return $invoiceMock;
+    }
+}

--- a/tests/Unit/AeatClientHybridTest.php
+++ b/tests/Unit/AeatClientHybridTest.php
@@ -102,6 +102,18 @@ class AeatClientHybridTest extends TestCase
             {
                 return null;
             }
+            public function getCorrectedBaseAmount(): ?float
+            {
+                return null;
+            }
+            public function getCorrectedTaxAmount(): ?float
+            {
+                return null;
+            }
+            public function getCorrectedSurchargeAmount(): ?float
+            {
+                return null;
+            }
         };
 
         // Mock AeatClient to avoid real SOAP calls but verify method signature

--- a/tests/Unit/AeatClientRepresentativeTest.php
+++ b/tests/Unit/AeatClientRepresentativeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Squareetlabs\VeriFactu\Services\AeatClient;
+use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
+use Squareetlabs\VeriFactu\Enums\InvoiceType;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Colaborador social (entidad colaboradora AEAT): la plataforma remite con su
+ * propio certificado en nombre del obligado de emisión. La Cabecera debe
+ * incluir el bloque Representante, y el ObligadoEmision sigue siendo el emisor.
+ */
+class AeatClientRepresentativeTest extends TestCase
+{
+    public function testRepresentativeBlockIsAddedToCabecera(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Cliente Emisor SL', 'vat' => 'B22222222']);
+        Config::set('verifactu.representative', ['name' => '', 'vat' => '']);
+
+        $soapClientMock = $this->mockSoapExpecting(function ($args) {
+            $cabecera = $args[0]['Cabecera'];
+
+            return $cabecera['ObligadoEmision']['NIF'] === 'B22222222'
+                && $cabecera['Representante']['NIF'] === 'B99999999'
+                && $cabecera['Representante']['NombreRazon'] === 'Quandium Platform SL';
+        });
+
+        $client = $this->makeClient($soapClientMock, representative: [
+            'name' => 'Quandium Platform SL',
+            'vat' => 'B99999999',
+        ]);
+
+        $result = $client->sendInvoice($this->makeInvoiceMock());
+        $this->assertEquals('success', $result['status']);
+    }
+
+    public function testRepresentativeFallsBackToConfig(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Cliente Emisor SL', 'vat' => 'B22222222']);
+        Config::set('verifactu.representative', ['name' => 'Config Rep SL', 'vat' => 'B88888888']);
+
+        $soapClientMock = $this->mockSoapExpecting(
+            fn ($args) => $args[0]['Cabecera']['Representante']['NIF'] === 'B88888888',
+        );
+
+        $client = $this->makeClient($soapClientMock);
+
+        $result = $client->sendInvoice($this->makeInvoiceMock());
+        $this->assertEquals('success', $result['status']);
+    }
+
+    public function testNoRepresentativeBlockWhenNotConfigured(): void
+    {
+        Config::set('verifactu.issuer', ['name' => 'Emisor Directo SL', 'vat' => 'B22222222']);
+        Config::set('verifactu.representative', ['name' => '', 'vat' => '']);
+
+        $soapClientMock = $this->mockSoapExpecting(
+            fn ($args) => !isset($args[0]['Cabecera']['Representante']),
+        );
+
+        $client = $this->makeClient($soapClientMock);
+
+        $result = $client->sendInvoice($this->makeInvoiceMock());
+        $this->assertEquals('success', $result['status']);
+    }
+
+    private function mockSoapExpecting(callable $assertion): \SoapClient
+    {
+        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
+            ->getMock();
+
+        $soapClientMock->expects($this->once())
+            ->method('__soapCall')
+            ->with('RegFactuSistemaFacturacion', $this->callback($assertion))
+            ->willReturn(new \stdClass());
+
+        return $soapClientMock;
+    }
+
+    private function makeClient(\SoapClient $soapClientMock, ?array $representative = null): AeatClient
+    {
+        return new class ('/path/cert.pem', 'pwd', false, true, null, $representative, $soapClientMock) extends AeatClient {
+            private $soapClientMock;
+
+            public function __construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative, $soapClientMock)
+            {
+                parent::__construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative);
+                $this->soapClientMock = $soapClientMock;
+            }
+
+            protected function getSoapClient(): \SoapClient
+            {
+                return $this->soapClientMock;
+            }
+        };
+    }
+
+    private function makeInvoiceMock(): VeriFactuInvoice
+    {
+        $invoiceMock = $this->createMock(VeriFactuInvoice::class);
+        $invoiceMock->method('getInvoiceNumber')->willReturn('FAC-2026-000010');
+        $invoiceMock->method('getIssueDate')->willReturn(now());
+        $invoiceMock->method('getInvoiceType')->willReturn(InvoiceType::STANDARD->value);
+        $invoiceMock->method('getTotalAmount')->willReturn(121.0);
+        $invoiceMock->method('getTaxAmount')->willReturn(21.0);
+        $invoiceMock->method('getBreakdowns')->willReturn(collect());
+        $invoiceMock->method('getRecipients')->willReturn(collect());
+        $invoiceMock->method('getPreviousHash')->willReturn(null);
+        $invoiceMock->method('getOperationDescription')->willReturn('Venta');
+        $invoiceMock->method('getOperationDate')->willReturn(null);
+        $invoiceMock->method('getTaxPeriod')->willReturn(null);
+        $invoiceMock->method('getCorrectionType')->willReturn(null);
+        $invoiceMock->method('getExternalReference')->willReturn(null);
+
+        return $invoiceMock;
+    }
+}

--- a/tests/Unit/AeatClientRepresentativeTest.php
+++ b/tests/Unit/AeatClientRepresentativeTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Tests\TestCase;
-use Squareetlabs\VeriFactu\Services\AeatClient;
-use Squareetlabs\VeriFactu\Contracts\VeriFactuInvoice;
-use Squareetlabs\VeriFactu\Enums\InvoiceType;
+use Tests\Support\InteractsWithAeatClient;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -17,6 +15,8 @@ use Illuminate\Support\Facades\Config;
  */
 class AeatClientRepresentativeTest extends TestCase
 {
+    use InteractsWithAeatClient;
+
     public function testRepresentativeBlockIsAddedToCabecera(): void
     {
         Config::set('verifactu.issuer', ['name' => 'Cliente Emisor SL', 'vat' => 'B22222222']);
@@ -30,7 +30,7 @@ class AeatClientRepresentativeTest extends TestCase
                 && $cabecera['Representante']['NombreRazon'] === 'Quandium Platform SL';
         });
 
-        $client = $this->makeClient($soapClientMock, representative: [
+        $client = $this->makeAeatClient($soapClientMock, representative: [
             'name' => 'Quandium Platform SL',
             'vat' => 'B99999999',
         ]);
@@ -48,9 +48,8 @@ class AeatClientRepresentativeTest extends TestCase
             fn ($args) => $args[0]['Cabecera']['Representante']['NIF'] === 'B88888888',
         );
 
-        $client = $this->makeClient($soapClientMock);
+        $result = $this->makeAeatClient($soapClientMock)->sendInvoice($this->makeInvoiceMock());
 
-        $result = $client->sendInvoice($this->makeInvoiceMock());
         $this->assertEquals('success', $result['status']);
     }
 
@@ -63,62 +62,8 @@ class AeatClientRepresentativeTest extends TestCase
             fn ($args) => !isset($args[0]['Cabecera']['Representante']),
         );
 
-        $client = $this->makeClient($soapClientMock);
+        $result = $this->makeAeatClient($soapClientMock)->sendInvoice($this->makeInvoiceMock());
 
-        $result = $client->sendInvoice($this->makeInvoiceMock());
         $this->assertEquals('success', $result['status']);
-    }
-
-    private function mockSoapExpecting(callable $assertion): \SoapClient
-    {
-        $soapClientMock = $this->getMockBuilder(\SoapClient::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__setLocation', '__soapCall', '__getLastRequest', '__getLastResponse'])
-            ->getMock();
-
-        $soapClientMock->expects($this->once())
-            ->method('__soapCall')
-            ->with('RegFactuSistemaFacturacion', $this->callback($assertion))
-            ->willReturn(new \stdClass());
-
-        return $soapClientMock;
-    }
-
-    private function makeClient(\SoapClient $soapClientMock, ?array $representative = null): AeatClient
-    {
-        return new class ('/path/cert.pem', 'pwd', false, true, null, $representative, $soapClientMock) extends AeatClient {
-            private $soapClientMock;
-
-            public function __construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative, $soapClientMock)
-            {
-                parent::__construct($certPath, $certPassword, $production, $verifactuMode, $issuer, $representative);
-                $this->soapClientMock = $soapClientMock;
-            }
-
-            protected function getSoapClient(): \SoapClient
-            {
-                return $this->soapClientMock;
-            }
-        };
-    }
-
-    private function makeInvoiceMock(): VeriFactuInvoice
-    {
-        $invoiceMock = $this->createMock(VeriFactuInvoice::class);
-        $invoiceMock->method('getInvoiceNumber')->willReturn('FAC-2026-000010');
-        $invoiceMock->method('getIssueDate')->willReturn(now());
-        $invoiceMock->method('getInvoiceType')->willReturn(InvoiceType::STANDARD->value);
-        $invoiceMock->method('getTotalAmount')->willReturn(121.0);
-        $invoiceMock->method('getTaxAmount')->willReturn(21.0);
-        $invoiceMock->method('getBreakdowns')->willReturn(collect());
-        $invoiceMock->method('getRecipients')->willReturn(collect());
-        $invoiceMock->method('getPreviousHash')->willReturn(null);
-        $invoiceMock->method('getOperationDescription')->willReturn('Venta');
-        $invoiceMock->method('getOperationDate')->willReturn(null);
-        $invoiceMock->method('getTaxPeriod')->willReturn(null);
-        $invoiceMock->method('getCorrectionType')->willReturn(null);
-        $invoiceMock->method('getExternalReference')->willReturn(null);
-
-        return $invoiceMock;
     }
 }

--- a/tests/Unit/AeatSubmissionResponseTest.php
+++ b/tests/Unit/AeatSubmissionResponseTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Squareetlabs\VeriFactu\Services\AeatSubmissionResponse;
+
+class AeatSubmissionResponseTest extends TestCase
+{
+    public function testParsesAcceptedResponseWithCsvAndSingleLine(): void
+    {
+        // SoapClient devuelve stdClass anidado; RespuestaLinea única (no lista).
+        $aeat = json_decode(json_encode([
+            'EstadoEnvio' => 'Correcto',
+            'CSV' => 'ABC123DEF456GHI7',
+            'RespuestaLinea' => [
+                'IDFactura' => ['NumSerieFactura' => 'FAC-2026-000001'],
+                'EstadoRegistro' => 'Correcto',
+            ],
+        ]));
+
+        $response = AeatSubmissionResponse::fromClientResult([
+            'status' => 'success',
+            'aeat_response' => $aeat,
+            'request' => '<xml/>',
+            'response' => '<xml/>',
+        ]);
+
+        $this->assertTrue($response->accepted());
+        $this->assertFalse($response->partiallyAccepted());
+        $this->assertFalse($response->rejected());
+        $this->assertEquals('ABC123DEF456GHI7', $response->csv);
+        $this->assertCount(1, $response->lines);
+        $this->assertEquals('FAC-2026-000001', $response->lines[0]['invoice_number']);
+        $this->assertEquals('Correcto', $response->lines[0]['status']);
+        $this->assertNull($response->firstError());
+    }
+
+    public function testParsesPartiallyCorrectResponseWithLineErrors(): void
+    {
+        $aeat = json_decode(json_encode([
+            'EstadoEnvio' => 'ParcialmenteCorrecto',
+            'RespuestaLinea' => [
+                [
+                    'IDFactura' => ['NumSerieFactura' => 'FAC-2026-000001'],
+                    'EstadoRegistro' => 'Correcto',
+                ],
+                [
+                    'IDFactura' => ['NumSerieFactura' => 'FAC-2026-000002'],
+                    'EstadoRegistro' => 'Incorrecto',
+                    'CodigoErrorRegistro' => 1117,
+                    'DescripcionErrorRegistro' => 'Huella no coincide con la cadena',
+                ],
+            ],
+        ]));
+
+        $response = AeatSubmissionResponse::fromClientResult([
+            'status' => 'success',
+            'aeat_response' => $aeat,
+        ]);
+
+        $this->assertFalse($response->accepted());
+        $this->assertTrue($response->partiallyAccepted());
+        $this->assertCount(2, $response->lines);
+        $this->assertEquals('1117 Huella no coincide con la cadena', $response->firstError());
+    }
+
+    public function testTransportErrorIsRejectedWithMessage(): void
+    {
+        $response = AeatSubmissionResponse::fromClientResult([
+            'status' => 'error',
+            'message' => 'SoapFault: Could not connect to host',
+        ]);
+
+        $this->assertFalse($response->accepted());
+        $this->assertTrue($response->rejected());
+        $this->assertNull($response->sendStatus);
+        $this->assertEquals('SoapFault: Could not connect to host', $response->firstError());
+    }
+
+    public function testToArrayIsSerializableForAuditStorage(): void
+    {
+        $response = AeatSubmissionResponse::fromClientResult([
+            'status' => 'success',
+            'aeat_response' => json_decode(json_encode(['EstadoEnvio' => 'Correcto'])),
+        ]);
+
+        $array = $response->toArray();
+
+        $this->assertTrue($array['transport_success']);
+        $this->assertEquals('Correcto', $array['send_status']);
+        $this->assertIsString(json_encode($array));
+    }
+}

--- a/tests/Unit/ConfigCertificateProviderTest.php
+++ b/tests/Unit/ConfigCertificateProviderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Squareetlabs\VeriFactu\Contracts\CertificateProvider;
+use Squareetlabs\VeriFactu\Exceptions\VeriFactuException;
+use Squareetlabs\VeriFactu\Services\ConfigCertificateProvider;
+use Illuminate\Support\Facades\Config;
+
+class ConfigCertificateProviderTest extends TestCase
+{
+    private string $tmpCert;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tmpCert = tempnam(sys_get_temp_dir(), 'vf-cert-');
+        file_put_contents($this->tmpCert, 'dummy-pem');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tmpCert);
+        parent::tearDown();
+    }
+
+    public function testResolvesCertificateFromConfig(): void
+    {
+        Config::set('verifactu.aeat.cert_path', $this->tmpCert);
+        Config::set('verifactu.aeat.cert_password', 'secret');
+
+        $ref = (new ConfigCertificateProvider())->resolve();
+
+        $this->assertEquals($this->tmpCert, $ref->path);
+        $this->assertEquals('secret', $ref->password);
+    }
+
+    public function testNullPasswordIsPreserved(): void
+    {
+        Config::set('verifactu.aeat.cert_path', $this->tmpCert);
+        Config::set('verifactu.aeat.cert_password', null);
+
+        $ref = (new ConfigCertificateProvider())->resolve();
+
+        $this->assertNull($ref->password);
+    }
+
+    public function testThrowsWhenNoCertificateConfigured(): void
+    {
+        Config::set('verifactu.aeat.cert_path', '');
+
+        $this->expectException(VeriFactuException::class);
+        $this->expectExceptionMessage('No certificate configured');
+
+        (new ConfigCertificateProvider())->resolve();
+    }
+
+    public function testThrowsWhenCertificateFileMissing(): void
+    {
+        Config::set('verifactu.aeat.cert_path', '/nonexistent/cert.pem');
+
+        $this->expectException(VeriFactuException::class);
+        $this->expectExceptionMessage('not found');
+
+        (new ConfigCertificateProvider())->resolve();
+    }
+
+    public function testIsBoundAsDefaultImplementationInContainer(): void
+    {
+        $this->assertInstanceOf(
+            ConfigCertificateProvider::class,
+            $this->app->make(CertificateProvider::class),
+        );
+    }
+}

--- a/tests/Unit/ContractComplianceTest.php
+++ b/tests/Unit/ContractComplianceTest.php
@@ -95,6 +95,18 @@ class ContractComplianceTest extends TestCase
             {
                 return null;
             }
+            public function getCorrectedBaseAmount(): ?float
+            {
+                return null;
+            }
+            public function getCorrectedTaxAmount(): ?float
+            {
+                return null;
+            }
+            public function getCorrectedSurchargeAmount(): ?float
+            {
+                return null;
+            }
         };
 
         $this->assertInstanceOf(VeriFactuInvoice::class, $customInvoice);


### PR DESCRIPTION
## Qué cambia

Preparación de la v2.0.0 con tres bloques, todos **retrocompatibles** (parámetros nuevos opcionales):

### 1. Soporte de cadena persistida por el host y multi-tenant
- `AeatClient` acepta **emisor por instancia** (5º argumento del constructor): en plataformas multi-tenant cada empresa es un obligado de emisión distinto; antes el emisor solo podía venir de `config('verifactu.issuer')`.
- `sendInvoice()` acepta un 3er argumento `$record` con **huella y `FechaHoraHusoGenRegistro` precalculadas**. Imprescindible cuando la aplicación host persiste su propia cadena en el momento de la emisión: la huella remitida a AEAT debe ser byte a byte la almacenada — recalcularla en el envío asíncrono (comportamiento anterior, con `Carbon::now()`) rompería la integridad de la cadena.
- `buildFingerprint()` delega en `HashHelper::generateInvoiceHash()`: única implementación de la especificación de huella AEAT v0.1.2, la que tiene tests de conformidad. Antes estaba duplicada.

### 2. Entidad colaboradora AEAT (colaborador social)
- Bloque **`Representante`** en la `Cabecera`, configurable globalmente (`verifactu.representative` / `VERIFACTU_REP_NAME`, `VERIFACTU_REP_VAT`) o por instancia (6º argumento). Permite que una plataforma remita con su propio certificado en nombre de sus clientes, sin que los emisores aporten certificado. Si no se configura, la cabecera no cambia.

### 3. API de integración para hosts
- Contrato **`CertificateProvider`** + **`ConfigCertificateProvider`** por defecto (lee `verifactu.aeat.cert_path/cert_password`, valida existencia del fichero). Re-vinculable para almacenes propios (por emisor, Vault, S3+KMS…).
- **`AeatClientFactory`**: construye `AeatClient` desde config + `CertificateProvider`, con emisor/representante por llamada — el transport de un host queda reducido a mapear su registro de cadena.
- **`AeatSubmissionResponse`**: DTO tipado sobre el array crudo de `sendInvoice()`; parsea `EstadoEnvio`, `CSV` y `RespuestaLinea` (objeto único o lista) con `accepted()` / `partiallyAccepted()` / `rejected()` / `firstError()` / `toArray()`.
- Bindings registrados en `VeriFactuServiceProvider`.

### Fixes
- `AeatClientHybridTest` y `ContractComplianceTest` no compilaban: sus implementaciones anónimas de `VeriFactuInvoice` no se actualizaron al añadirse `getCorrectedBaseAmount/TaxAmount/SurchargeAmount` al contrato.

## Por qué

Surge de la integración del paquete en Quandium (SaaS de facturación multi-tenant que opera como entidad colaboradora AEAT), pero todas las piezas son genéricas y benefician a cualquier consumidor: el bug de la huella recalculada afectaría a cualquier host con envío asíncrono y cadena propia, y la respuesta tipada elimina el parseo manual del stdClass del SOAP en cada aplicación.

## Notas para revisión

- **Suite completa: 72 passed (191 assertions), 17 tests nuevos** — `AeatClientHostChainTest`, `AeatClientRepresentativeTest`, `ConfigCertificateProviderTest`, `AeatClientFactoryTest`, `AeatSubmissionResponseTest`.
- Punto a validar contra la especificación del WS: los nombres del bloque `Representante` (`NombreRazon`/`NIF`) en `Cabecera` siguen el esquema `SuministroInformacion.xsd`; conviene contrastarlo en el entorno de pruebas de AEAT antes del tag.
- `README` y `CHANGELOG` actualizados con la sección de colaborador social y ejemplos de la factory/DTO.
- Tras el merge: tag `v2.0.0` para Packagist. El consumidor (Quandium) pasará entonces de path-repository a `^2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)